### PR TITLE
feat: Update instance type to `Standard_D2as_v4`

### DIFF
--- a/deployment/chat-deployment.yaml
+++ b/deployment/chat-deployment.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/managedOnlineDeployment.schema.json
 model: azureml:contoso-chat-model:1
-instance_type: Standard_DS3_v2
+instance_type: Standard_D2as_v4
 instance_count: 1
 request_settings:
   request_timeout_ms: 50000


### PR DESCRIPTION
**DO NOT MERGE UNTIL WE VERIFY THAT THE UPDATED DEPLOYMENT ACTUALLY WORKS**

Use a less powerful instance type to minimise costs.